### PR TITLE
Export comprehensive file for filtering

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,9 +4,11 @@ META_CSV = "HEAL CDEs matching LOINC, NIH CDE or caDSR CDEs - HEAL CDEs mapped t
 INPUT_FILES = FileList['output/**/*.json']
 NODES_FILES = INPUT_FILES.pathmap("%{^output/,annotated/}X_nodes.jsonl")
 EDGES_FILES = INPUT_FILES.pathmap("%{^output/,annotated/}X_edges.jsonl")
+COMPREHENSIVE_FILES = INPUT_FILES.pathmap("%{^output/,annotated/}X_comprehensive.jsonl")
 OUTPUT_FILES = INPUT_FILES.pathmap("%{^output/,annotated/}X.complete")
 OUTPUT_NODES = "annotated/output_nodes.jsonl"
 OUTPUT_EDGES = "annotated/output_edges.jsonl"
+OUTPUT_COMPREHENSIVE = "annotated/output_comprehensive.jsonl"
 
 directory "annotated"
 
@@ -43,12 +45,19 @@ task :concat_kgx do
     end
   end
 
-   # Shouldn't be any duplicates in this file.
+   # Shouldn't be any duplicates in these files.
    File.open(OUTPUT_EDGES, "w") do |output|
     EDGES_FILES.each do |edges_file|
       IO.readlines(edges_file).each do |line|
         output.write(line)
       end
     end
+   end
+   File.open(OUTPUT_COMPREHENSIVE, "w") do |output|
+     COMPREHENSIVE_FILES.each do |comprehensive_files|
+       IO.readlines(comprehensive_files).each do |line|
+         output.write(line)
+       end
+     end
    end
 end

--- a/annotators/scigraph/scigraph-api-annotator.py
+++ b/annotators/scigraph/scigraph-api-annotator.py
@@ -89,6 +89,19 @@ IGNORED_CONCEPTS = {
     'MONDO:0004980',                    # "allergy" is not atopic eczema
     'MONDO:0009994',                    # "arms" are not alveolar rhabdomyosarcoma
     # Stopped at decompression sickness (MONDO:0020797): 5 CRFs
+    'PUBCHEM.COMPOUND:5460341',         # "could" is not Calcium: 19 CRFs
+    'GO:0044309',                       # "neuron spine" isn't right -- "spine" should match UBERON:0001130 (and does)
+    'UBERON:0015230',                   # "dorsal vessel heart" isn't as good as "heart" (UBERON:0000948), which we match
+    'KEGG.COMPOUND:C00701',             # "based" is not a base
+    'UBERON:0010230',                   # "eyeball of camera-type eye" is probably too specific
+    'PUBCHEM.COMPOUND:34756',           # "same" is not S-Adenosyl-L-methionine (PUBCHEM.COMPOUND:34756): 8 CRFs
+
+    # TODO:
+    # - chronic obstructive pulmonary disease (MONDO:0005002): 17 CRFs -> matches "cold"
+    # - leg (UBERON:0000978) -> matches "lower extremity"
+    # - Needs more investigation:
+    #   - hindlimb zeugopod (UBERON:0003823): 14 CRFs
+    # Stopped at forelimb stylopod (UBERON:0003822): 10 CRFs
 }
 
 # Some URLs we use.


### PR DESCRIPTION
KGX dumps are inadequate for checking and cleaning up incorrect concepts, in particular in checking whether terms that could not be normalized are useful to us. This PR modifies the script to generate a (massive) JSONL file that contains all of that information.