### PR TITLE
Fix NodeNorm URL and add `clean` target for Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,8 @@ ANNOTATOR = 'annotators/scigraph/scigraph-api-annotator.py'
 OUTPUT_DIR = 'annotated'
 
 # Input/output files
+require 'rake/clean'
+CLEAN.include OUTPUT_DIR
 META_CSV = "HEAL CDEs matching LOINC, NIH CDE or caDSR CDEs - HEAL CDEs mapped to LOINC and caDSR - 2021sep7.csv"
 INPUT_FILES = FileList['output/json/**/*.json']
 NODES_FILES = INPUT_FILES.pathmap("%{^output/,#{OUTPUT_DIR}/}X_nodes.jsonl")

--- a/annotators/medtype/medtype-annotator.py
+++ b/annotators/medtype/medtype-annotator.py
@@ -46,7 +46,7 @@ session.mount('http://', http_adapter)
 session.mount('https://', http_adapter)
 
 # Some URLs we use.
-TRANSLATOR_NORMALIZATION_URL = 'https://nodenormalization-sri.renci.org/1.2/get_normalized_nodes'
+TRANSLATOR_NORMALIZATION_URL = 'https://nodenormalization-sri.renci.org/1.3/get_normalized_nodes'
 MEDTYPE_API_URI = 'http://localhost:8125/run_linker'
 
 

--- a/annotators/scigraph/scigraph-api-annotator.py
+++ b/annotators/scigraph/scigraph-api-annotator.py
@@ -111,7 +111,7 @@ IGNORED_CONCEPTS = {
 }
 
 # Some URLs we use.
-TRANSLATOR_NORMALIZATION_URL = 'https://nodenormalization-sri.renci.org/1.2/get_normalized_nodes'
+TRANSLATOR_NORMALIZATION_URL = 'https://nodenormalization-sri.renci.org/1.3/get_normalized_nodes'
 MONARCH_API_URI = 'https://api.monarchinitiative.org/api/nlp/annotate/entities'
 
 


### PR DESCRIPTION
This PR makes two changes:
1. It fixes the URL used for NodeNorm so that normalization of identifiers can continue.
2. It adds a `clean` target for the Rakefile, so that `rake clean` can be used to delete all annotated files.