### PR TITLE
Sort by file type

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ $ source venv/bin/activate
 $ pip install -r requirements.txt
 ```
 
+### Generating HEAL CDE information
+
+```shell
+$ mkdir output-2024apr27
+$ source venv/bin/activate
+$ python downloaders/heal_cde_repo_downloader.py output-2024apr27
+```
+
 ### Generating JSON files
 
 The script generators/excel2cde.py recursively converts Excel files in the

--- a/downloaders/annotators/scigraph/scigraph_api_annotator.py
+++ b/downloaders/annotators/scigraph/scigraph_api_annotator.py
@@ -113,7 +113,7 @@ IGNORED_CONCEPTS = {
 # Some URLs we use.
 TRANSLATOR_NORMALIZATION_URL = 'https://nodenormalization-sri.renci.org/1.3/get_normalized_nodes'
 # MONARCH_API_URI = 'https://api.monarchinitiative.org/api/nlp/annotate/entities'
-MONARCH_API_URI = 'https://api-biolink.monarchinitiative.org/api/nlp/annotate/entities'
+MONARCH_API_URI = 'http://api.monarchinitiative.org/v3/api/annotate/entities'
 
 
 def get_id_for_heal_crf(filename):
@@ -189,19 +189,19 @@ def ner_via_monarch_api(crf_id, text, included_categories=[], excluded_categorie
     except json.JSONDecodeError as err:
         logging.error(f"Could not parse Monarch NER POST result for text '{text}': {err}")
         result_json = {
-            'spans': []
+            'tokens': []
         }
 
     tokens = []
-    spans = result_json['spans']
+    spans = result_json['tokens']
     logging.info(f"Querying Monarch API for '{text}' produced the following tokens (CRF ID {crf_id}):")
     for span in spans:
         for token in span['token']:
             token_definition = dict(
                 text=span['text'],
                 id=token['id'],
+                name=token['name'],
                 categories=token.get('category', []),
-                terms=token['terms']
             )
 
             logging.debug(f" - [{token['id']}] \"{token['terms']}\": {token_definition}")

--- a/downloaders/annotators/scigraph/scigraph_api_annotator.py
+++ b/downloaders/annotators/scigraph/scigraph_api_annotator.py
@@ -111,7 +111,7 @@ IGNORED_CONCEPTS = {
 }
 
 # Some URLs we use.
-TRANSLATOR_NORMALIZATION_URL = 'https://nodenormalization-sri.renci.org/1.3/get_normalized_nodes'
+TRANSLATOR_NORMALIZATION_URL = 'https://nodenormalization-sri.renci.org/get_normalized_nodes'
 # MONARCH_API_URI = 'https://api.monarchinitiative.org/api/nlp/annotate/entities'
 MONARCH_API_URI = 'http://api.monarchinitiative.org/v3/api/annotate/entities'
 

--- a/downloaders/annotators/scigraph/scigraph_api_annotator.py
+++ b/downloaders/annotators/scigraph/scigraph_api_annotator.py
@@ -115,6 +115,7 @@ TRANSLATOR_NORMALIZATION_URL = 'https://nodenormalization-sri.renci.org/1.3/get_
 # MONARCH_API_URI = 'https://api.monarchinitiative.org/api/nlp/annotate/entities'
 MONARCH_API_URI = 'https://api-biolink.monarchinitiative.org/api/nlp/annotate/entities'
 
+
 def get_id_for_heal_crf(filename):
     """ Get an ID for a HEAL CRF. """
     return f'HEALCDE:{urllib.parse.quote(filename)}'

--- a/downloaders/heal_cde_repo_downloader.py
+++ b/downloaders/heal_cde_repo_downloader.py
@@ -88,7 +88,14 @@ def heal_cde_repo_downloader(output, heal_cde_csv_download, add_cde_count_to_des
         elif title.endswith('-crf-swedish.docx'):
             crf_id = title[0:-17]
             lang = 'sv'
+        elif title.endswith('-crf-swedish.pdf'):
+            crf_id = title[0:-16]
+            lang = 'sv'
         elif title.endswith('-copyright-statement.docx'):
+            crf_id = title[0:-25]
+        elif title.endswith('-copyright_statement.docx'):
+            crf_id = title[0:-25]
+        elif title.endswith('-copyright-statement.pdf'):
             crf_id = title[0:-25]
         elif title.endswith('-copyright-statement_.docx'):
             crf_id = title[0:-26]
@@ -98,12 +105,16 @@ def heal_cde_repo_downloader(output, heal_cde_csv_download, add_cde_count_to_des
             crf_id = title[0:-35]
         elif title.endswith('-crf.docx'):
             crf_id = title[0:-9]
+        elif title.endswith('-cde.docx'):
+            crf_id = title[0:-9]
         elif title.endswith('-crf.pdf'):
             crf_id = title[0:-8]
         elif title.endswith('-cde.pdf'):
             crf_id = title[0:-8]
         elif title.endswith('-cde.xlsx'):
             crf_id = title[0:-9]
+        elif title.endswith('-crf-.xlsx'):
+            crf_id = title[0:-10]
         elif title.endswith('-cde_.xlsx'):
             crf_id = title[0:-10]
         elif title.endswith('-cdes.xlsx'):

--- a/downloaders/heal_cde_repo_downloader.py
+++ b/downloaders/heal_cde_repo_downloader.py
@@ -36,8 +36,8 @@ MIME_PDF = 'application/pdf'
 HEAL_CDE_CSV_DOWNLOAD = "https://heal.nih.gov/data/common-data-elements-repository/export?page&_format=csv"
 
 # Sort order for languages
-LANGUAGE_ORDER = {'en': 3, 'es': 2, 'sv': 1}
-MIME_TYPE_ORDER = {MIME_DOCX: 3, MIME_XLSX: 2, MIME_PDF: 1}
+LANGUAGE_ORDER = {'en': 1, 'es': 2, 'sv': 3}
+MIME_TYPE_ORDER = {MIME_DOCX: 1, MIME_PDF: 2, MIME_XLSX: 3}
 
 # Configure logging.
 logging.basicConfig(level=logging.INFO)
@@ -324,10 +324,10 @@ def heal_cde_repo_downloader(
 
         # Step 3. Reorder the files in order of LANGUAGE_ORDER and FILE_TYPE_ORDER (in that order).
         def sort_key(file_entry):
-            assert len(LANGUAGE_ORDER) < 100, 'This sort key only works when there are less than 99 languages.'
-            return LANGUAGE_ORDER[file_entry['lang']] * 100 + MIME_TYPE_ORDER[file_entry['mime-type']]
+            return LANGUAGE_ORDER[file_entry['lang']], MIME_TYPE_ORDER[file_entry['mime-type']]
 
         files = sorted(files, key=sort_key)
+        logging.info(f"Sorted files: {"; ".join(map(lambda f: f['url'], files))}")
 
         # Step 4. Convert JSON to KGX.
         # Set up the KGX graph

--- a/downloaders/heal_cde_repo_downloader.py
+++ b/downloaders/heal_cde_repo_downloader.py
@@ -327,7 +327,7 @@ def heal_cde_repo_downloader(
             return LANGUAGE_ORDER[file_entry['lang']], MIME_TYPE_ORDER[file_entry['mime-type']]
 
         files = sorted(files, key=sort_key)
-        logging.info(f"Sorted files: {"; ".join(map(lambda f: f['url'], files))}")
+        logging.info(f"Sorted files: {'; '.join(map(lambda f: f['url'], files))}")
 
         # Step 4. Convert JSON to KGX.
         # Set up the KGX graph

--- a/downloaders/heal_cde_repo_downloader.py
+++ b/downloaders/heal_cde_repo_downloader.py
@@ -36,7 +36,7 @@ MIME_PDF = 'application/pdf'
 HEAL_CDE_CSV_DOWNLOAD = "https://heal.nih.gov/data/common-data-elements-repository/export?page&_format=csv"
 
 # Sort order for languages
-LANGUAGE_ORDER = {'en': 1, 'es': 2, 'sv': 3}
+LANGUAGE_ORDER = {'en': 1, 'es': 2, 'zh-CN': 3, 'zh-TW': 4, 'ja': 5, 'ko': 6, 'sv': 7}
 MIME_TYPE_ORDER = {MIME_DOCX: 1, MIME_PDF: 2, MIME_XLSX: 3}
 
 # Configure logging.
@@ -157,6 +157,18 @@ def heal_cde_repo_downloader(
         elif title.endswith('-crf-swedish.pdf'):
             crf_id = title[0:-16]
             lang = 'sv'
+        elif title.endswith('-crf-japanese.docx'):
+            crf_id = title[0:-18]
+            lang = 'ja'
+        elif title.endswith('-korean.docx'):
+            crf_id = title[0:-12]
+            lang = 'ko'
+        elif title.endswith('-crf-simplified-chinese.docx'):
+            crf_id = title[0:-28]
+            lang = 'zh-CN'
+        elif title.endswith('-crf-traditional-chinese.docx'):
+            crf_id = title[0:-29]
+            lang = 'zh-TW'
         elif title.endswith('-copyright-statement.docx'):
             crf_id = title[0:-25]
         elif title.endswith('-copyright_statement.docx'):

--- a/downloaders/heal_cde_repo_downloader.py
+++ b/downloaders/heal_cde_repo_downloader.py
@@ -341,8 +341,8 @@ def heal_cde_repo_downloader(
             graph.add_node_attribute('HEALCDE:' + crf_id, 'has_download', list(map(lambda x: x['url'], files)))
 
         # Create nodes for each download.
-        files_urls = set()
-        files_by_lang = collections.defaultdict(set)
+        files_urls = list()
+        files_by_lang = collections.defaultdict(list)
         for file in files:
             url = file['url']
 
@@ -354,8 +354,8 @@ def heal_cde_repo_downloader(
                 graph.add_node_attribute(url, 'description', file['description'])
                 graph.add_node_attribute(url, 'provided_by', heal_cde_source)
             else:
-                files_urls.add(url)
-                files_by_lang[file['lang']].add(url)
+                files_urls.append(url)
+                files_by_lang[file['lang']].append(url)
 
         if not export_files_as_nodes:
             graph.add_node_attribute('HEALCDE:' + crf_id, 'files', list(files_urls))

--- a/downloaders/heal_cde_repo_downloader.py
+++ b/downloaders/heal_cde_repo_downloader.py
@@ -343,7 +343,6 @@ def heal_cde_repo_downloader(
         # Create nodes for each download.
         files_urls = set()
         files_by_lang = collections.defaultdict(set)
-        files_urls.add(xlsx_file_url)
         for file in files:
             url = file['url']
 


### PR DESCRIPTION
This PR sorts file URLs for HEAL CDEs in the order (English > other languages, DOCX > PDF > XLSX) so that we preferentially point people to the CRFs instead of the XLSX files.

Closes #23.